### PR TITLE
Updating package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,17 @@
 {
   "name": "Kitematic",
+  "author": "Kitematic",
+  "description": "Simple Docker App management for Mac OS X.",
+  "homepage": "https://kitematic.com/",
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:kitematic/kitematic.git"
+  },
+  "bugs": "https://github.com/kitematic/kitematic/issues",
+  "licenses": [{
+    "type": "GNU",
+    "url": "https://raw.githubusercontent.com/kitematic/kitematic/master/LICENSE"
+  }],
   "main": "index.js",
   "version": "0.2.0",
   "dependencies": {


### PR DESCRIPTION
Should now pass http://package-json-validator.com/ with minimal warnings:

``` json
{
  "valid": true,
  "warnings": [
    "Missing recommended field: keywords",
    "Missing recommended field: contributors"
  ],
  "recommendations": [
    "Missing optional field: engines"
  ]
}
```
