### PR TITLE
Correction of typo in installer text

### DIFF
--- a/meteor/client/lib/installer.js
+++ b/meteor/client/lib/installer.js
@@ -98,7 +98,7 @@ Installer.steps = [
     },
     pastMessage: 'Setup the Kitematic VM (if required)',
     message: 'Setting up the Kitematic VM',
-    futureMessage: 'Set up the Kitematic VM(if required)'
+    futureMessage: 'Set up the Kitematic VM (if required)'
   },
 
   {


### PR DESCRIPTION
Addition of a missing space in the installer text.

![napkin 25 09-12-14 12 58 38 pm](https://cloud.githubusercontent.com/assets/47554/4256358/323840fa-3ab7-11e4-9873-00219fd8cf83.png)

Thanks for the awesome tool! I apologize I could not unsee this typo.
