### PR TITLE
Fix a 404 error on "Forgot Password" link

### DIFF
--- a/src/components/AccountLogin.react.js
+++ b/src/components/AccountLogin.react.js
@@ -63,7 +63,7 @@ module.exports = React.createClass({
   },
 
   handleClickForgotPassword: function () {
-    shell.openExternal('https://hub.docker.com/reset-password/');
+    shell.openExternal('https://id.docker.com/reset-password/');
   },
 
   render: function () {


### PR DESCRIPTION
The app returns ``https://hub.docker.com/reset-password/`` when the "Forgot your password?" prompt is clicked. The current working URL is ``https://id.docker.com/reset-password/``.

Signed-off-by: Matas Lauzadis <matas.lauzadis@gmail.com>